### PR TITLE
Add descriptions and video management with toggleable likes

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,8 @@
 import os
-from flask import Flask, render_template, request, redirect, url_for, send_from_directory
+from flask import Flask, render_template, request, redirect, url_for, session
 from flask_sqlalchemy import SQLAlchemy
 from werkzeug.utils import secure_filename
+from sqlalchemy import inspect, text
 
 app = Flask(__name__)
 app.config['UPLOAD_FOLDER'] = os.path.join('static', 'videos')
@@ -17,6 +18,7 @@ class Video(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     filename = db.Column(db.String(255), nullable=False)
     title = db.Column(db.String(255), nullable=False)
+    description = db.Column(db.Text, default='')
     likes = db.Column(db.Integer, default=0)
 
     comments = db.relationship('Comment', backref='video', cascade='all, delete-orphan')
@@ -28,6 +30,15 @@ class Comment(db.Model):
     content = db.Column(db.Text, nullable=False)
 
 
+with app.app_context():
+    db.create_all()
+    inspector = inspect(db.engine)
+    columns = [col['name'] for col in inspector.get_columns('video')]
+    if 'description' not in columns:
+        db.session.execute(text("ALTER TABLE video ADD COLUMN description TEXT DEFAULT ''"))
+        db.session.commit()
+
+
 @app.route('/')
 def index():
     videos = Video.query.all()
@@ -37,7 +48,15 @@ def index():
 @app.post('/like/<int:video_id>')
 def like(video_id):
     video = Video.query.get_or_404(video_id)
-    video.likes += 1
+    liked = session.get('liked_videos', [])
+    if video_id in liked:
+        if video.likes > 0:
+            video.likes -= 1
+        liked.remove(video_id)
+    else:
+        video.likes += 1
+        liked.append(video_id)
+    session['liked_videos'] = liked
     db.session.commit()
     return redirect(url_for('index'))
 
@@ -60,18 +79,47 @@ def upload():
             return 'Unauthorized', 403
         file = request.files.get('video')
         title = request.form.get('title', '')
+        description = request.form.get('description', '')
         if not file or not title:
             return 'Title and video required', 400
         filename = secure_filename(file.filename)
         save_path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
         file.save(save_path)
-        db.session.add(Video(filename=filename, title=title))
+        db.session.add(Video(filename=filename, title=title, description=description))
         db.session.commit()
         return redirect(url_for('index'))
-    return render_template('upload.html')
+    videos = Video.query.all()
+    return render_template('upload.html', videos=videos)
+
+
+@app.post('/delete/<int:video_id>')
+def delete(video_id):
+    password = request.form.get('password', '')
+    if password != os.environ.get('PRODUCER_PASSWORD', 'secret'):
+        return 'Unauthorized', 403
+    video = Video.query.get_or_404(video_id)
+    file_path = os.path.join(app.config['UPLOAD_FOLDER'], video.filename)
+    if os.path.exists(file_path):
+        os.remove(file_path)
+    db.session.delete(video)
+    db.session.commit()
+    return redirect(url_for('upload'))
+
+
+@app.post('/edit/<int:video_id>')
+def edit(video_id):
+    password = request.form.get('password', '')
+    if password != os.environ.get('PRODUCER_PASSWORD', 'secret'):
+        return 'Unauthorized', 403
+    video = Video.query.get_or_404(video_id)
+    title = request.form.get('title', '')
+    description = request.form.get('description', '')
+    if title:
+        video.title = title
+    video.description = description
+    db.session.commit()
+    return redirect(url_for('upload'))
 
 
 if __name__ == '__main__':
-    with app.app_context():
-        db.create_all()
     app.run(debug=True)

--- a/static/style.css
+++ b/static/style.css
@@ -20,7 +20,6 @@ body {
 }
 
 .video-wrapper {
-    position: relative;
 }
 
 .video-wrapper video {
@@ -29,9 +28,7 @@ body {
 }
 
 .like-form {
-    position: absolute;
-    bottom: 10px;
-    left: 10px;
+    margin-top: 10px;
 }
 
 .like-button {
@@ -40,6 +37,10 @@ body {
     color: #e74c3c;
     font-size: 24px;
     cursor: pointer;
+}
+
+.like-button.liked {
+    color: #c0392b;
 }
 
 .comments {

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,14 +9,19 @@
     {% for video in videos %}
     <div class="video-container">
         <h2>{{ video.title }}</h2>
+        <p>{{ video.description }}</p>
         <div class="video-wrapper">
             <video controls>
                 <source src="{{ url_for('static', filename='videos/' + video.filename) }}" type="video/mp4">
             </video>
-            <form class="like-form" action="{{ url_for('like', video_id=video.id) }}" method="post">
-                <button type="submit" class="like-button">&#10084; {{ video.likes }}</button>
-            </form>
         </div>
+        <form class="like-form" action="{{ url_for('like', video_id=video.id) }}" method="post">
+            {% if video.id in session.get('liked_videos', []) %}
+            <button type="submit" class="like-button liked">Unlike ({{ video.likes }})</button>
+            {% else %}
+            <button type="submit" class="like-button">Like ({{ video.likes }})</button>
+            {% endif %}
+        </form>
         <div class="comments">
             <h3>Comments</h3>
             <ul>

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -8,8 +8,30 @@
     <form method="post" enctype="multipart/form-data">
         <input type="password" name="password" placeholder="Password"><br>
         <input type="text" name="title" placeholder="Title"><br>
+        <textarea name="description" placeholder="Description"></textarea><br>
         <input type="file" name="video" accept="video/*"><br>
         <button type="submit">Upload</button>
     </form>
+
+    <h2>Existing Videos</h2>
+    {% for video in videos %}
+    <div class="video-container">
+        <video width="200" controls>
+            <source src="{{ url_for('static', filename='videos/' + video.filename) }}" type="video/mp4">
+        </video>
+        <form method="post" action="{{ url_for('edit', video_id=video.id) }}">
+            <input type="password" name="password" placeholder="Password"><br>
+            <input type="text" name="title" value="{{ video.title }}"><br>
+            <textarea name="description">{{ video.description }}</textarea><br>
+            <button type="submit">Save</button>
+        </form>
+        <form method="post" action="{{ url_for('delete', video_id=video.id) }}">
+            <input type="password" name="password" placeholder="Password"><br>
+            <button type="submit">Delete</button>
+        </form>
+    </div>
+    {% else %}
+    <p>No videos uploaded yet.</p>
+    {% endfor %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Allow users to like a video only once and unlike on second click, with like button positioned beneath the video
- Support video descriptions on upload and display, plus editing or deleting existing videos
- Show uploaded video summaries for producers to manage content
- Automatically add missing `description` column to existing databases at startup

## Testing
- `python -m py_compile app.py`
- `python app.py &` (server started, then terminated)


------
https://chatgpt.com/codex/tasks/task_e_68bb06ef25dc832b807d1fa43cfb4f3c